### PR TITLE
Connect bugfix

### DIFF
--- a/server.js
+++ b/server.js
@@ -158,7 +158,7 @@ var server = connect.createServer(
       next();
     }
   },
-  connect.staticProvider(__dirname + "/www")
+  connect.static(__dirname + "/www")
 );
 server.listen(5555);
 console.log(("HTTP Icecast server listening at: ".bold + "http://*:" + server.address().port).cyan);


### PR DESCRIPTION
Using current versions of all dependencies, server.js throws error: 

```
node.js:183
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Object function createServer() {
  if ('object' == typeof arguments[0]) {
    return new HTTPSServer(arguments[0], Array.prototype.slice.call(arguments, 1));
  } else {
    return new HTTPServer(Array.prototype.slice.call(arguments));
  }
} has no method 'staticProvider'
    at Object.<anonymous> (/media/5dea3207-20b3-407b-9f7c-78ed2ac03038/dev/NodeFloyd/server.js:161:11)
    at Module._compile (module.js:423:26)
    at Object..js (module.js:429:10)
    at Module.load (module.js:339:31)
    at Function._load (module.js:298:12)
    at Array.<anonymous> (module.js:442:10)
    at EventEmitter._tickCallback (node.js:175:26)
```

Awesome little application by the way!
